### PR TITLE
Fixes to siesta role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,8 @@
 
 - name: Install siesta dependencies
   become: true
-  apt:
+  ansible.builtin.apt:
+    update_cache: true
     name:
     - gfortran
     - make

--- a/tasks/siesta.yml
+++ b/tasks/siesta.yml
@@ -33,16 +33,6 @@
     creates: "{{ siesta_topdir }}/Obj/siesta"
   register: siesta_make
 
-- import_tasks: tests.yml
-
-- name: Install siesta executable
-  become: true
-  copy:
-    src: "{{ siesta_topdir }}/Obj/siesta"
-    dest: "{{ siesta_prefix }}/bin"
-    remote_src: true
-    mode: '0755'
-
 # This is needed to find the shared libs (notably libgridxc)
 
 - name: add dynamic library path config
@@ -56,6 +46,17 @@
   become: true
   command: ldconfig
   when: ld_conf.changed
+
+- import_tasks: tests.yml
+
+- name: Install siesta executable
+  become: true
+  copy:
+    src: "{{ siesta_topdir }}/Obj/siesta"
+    dest: "{{ siesta_prefix }}/bin"
+    remote_src: true
+    mode: '0755'
+
 
 - name: Add release notes (version)
   include_role:


### PR DESCRIPTION
Just yesterday I was testing the new ansible-galaxy siesta role on a clean VM, and I got a couple of errors:

- (on Ubuntu 20) some failures in apt-get. The solution I found was to add the equivalent of an 'apt update' at the beginning of my apt task. Now I see that the Quantum Mobile has an "ansible_prerequisites" role that does that, among other things. So this might be needed for my VM, but not for the QM. In any case, I do not think it hurts.

- The Siesta tests were failing due to not finding a shared library. This is because the ldconfig was done after the tests... I have fixed it now.